### PR TITLE
Allow setting configuration for the request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+build/
+dist/
+pyjolokia.egg-info/
+.tox/
+
+*.pyc
+

--- a/pyjolokia.py
+++ b/pyjolokia.py
@@ -18,8 +18,6 @@ except ImportError:
     from urllib.request import urlopen
 
 import base64
-import re
-import sys
 
 
 class Jolokia:
@@ -40,6 +38,7 @@ class Jolokia:
         self.data = None
         self.proxyConfig = {}
         self.authConfig = {}
+        self.reqConfig = {}
 
         self.timeout = kwargs.get('timeout', 10)
 
@@ -59,6 +58,21 @@ class Jolokia:
             self.authConfig['auth']['username'] = kwargs.get('httpusername')
         if 'httppassword' in kwargs:
             self.authConfig['auth']['password'] = kwargs.get('httppassword')
+
+    def config(self, **kwargs):
+        '''
+            Used to set configuration options for the request
+            see: http://www.jolokia.org/reference/html/protocol.html#processing-parameters
+
+            example
+
+            .. code-block:: python
+
+                j4p.config(ignoreErrors=True)
+        '''
+        if kwargs is not None:
+            for key, value in kwargs.iteritems():
+                self.reqConfig[key] = value
 
     def proxy(self, url, **kwargs):
         '''
@@ -132,6 +146,7 @@ class Jolokia:
     def __mkrequest(self, type, **kwargs):
         newRequest = {}
         newRequest['type'] = type
+        newRequest['config'] = self.reqConfig
 
         if type != 'list':
             newRequest['mbean'] = kwargs.get('mbean')

--- a/setup.py
+++ b/setup.py
@@ -5,21 +5,26 @@ kw = {}
 if sys.version_info >= (3,):
         kw['use_2to3'] = True
 
+
 class PyTest(Command):
     user_options = []
+
     def initialize_options(self):
         pass
+
     def finalize_options(self):
         pass
+
     def run(self):
-        import sys,subprocess
+        import sys
+        import subprocess
         errno = subprocess.call([sys.executable,
                                  'runtests.py',
                                  'tests.py'])
         raise SystemExit(errno)
 
 setup(name='pyjolokia',
-      version = '0.3.0',
+      version='0.3.1',
       description='Pure Python based Jolokia client',
       author='Colin Wood',
       license="Apache License Version 2.0",
@@ -30,7 +35,7 @@ setup(name='pyjolokia',
       long_description=open('README.rst').read(),
       include_package_data=True,
       keywords=['jolokia', 'jmx'],
-      cmdclass = {'test': PyTest},
+      cmdclass={'test': PyTest},
       classifiers=[
           'Development Status :: 4 - Beta'
           'Programming Language :: Python :: 2.6',

--- a/tests.py
+++ b/tests.py
@@ -24,6 +24,19 @@ class CoreJolikiaTests(unittest.TestCase):
         self.assertEqual(self.client.authConfig['auth']['password'],
                          'testpassword')
 
+    def test_set_config(self):
+        self.client.config(ignoreErrors=True)
+
+        self.assertEqual(self.client.reqConfig['ignoreErrors'], True)
+        response = self.client.request(
+            type='read',
+            mbean='java.lang:type=Threading',
+            attribute='ThreadCount')
+
+        json_data = response['json']
+
+        self.assertEqual(json_data['config']['ignoreErrors'], True)
+
     def test_read_response(self):
         response = self.client.request(
             type='read',


### PR DESCRIPTION
Added a method to allow setting arbitrary configuration for the request
For example ignoreErrors - http://www.jolokia.org/reference/html/protocol.html#processing-parameters
Removed unused imports
Bumped version number
Added my first ever python test. Hope it's ok.
