### PR TITLE
add support for remote targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.2"
-  - "3.3"
+  - "3.6"
+  - "3.7"
+  - "3.8"
 script: python setup.py test
 install:
     python setup.py install

--- a/pyjolokia.py
+++ b/pyjolokia.py
@@ -39,6 +39,7 @@ class Jolokia:
         self.proxyConfig = {}
         self.authConfig = {}
         self.reqConfig = {}
+        self.reqTarget = {}
 
         self.timeout = kwargs.get('timeout', 10)
 
@@ -73,6 +74,21 @@ class Jolokia:
         if kwargs is not None:
             for key, value in kwargs.iteritems():
                 self.reqConfig[key] = value
+
+    def target(self, **kwargs):
+        '''
+            Used to set configuration options for the request
+            see: http://www.jolokia.org/reference/html/protocol.html#processing-parameters
+
+            example
+
+            .. code-block:: python
+
+                j4p.target('service:jmx:rmi:///jndi/rmi://localhost:{}/jmxrmi' . format(8099))
+        '''
+        if kwargs is not None:
+            for key, value in kwargs.items():
+                self.reqTarget[key] = value
 
     def proxy(self, url, **kwargs):
         '''
@@ -146,6 +162,7 @@ class Jolokia:
         newRequest = {}
         newRequest['type'] = type
         newRequest['config'] = self.reqConfig
+        newRequest['target'] = self.reqTarget
 
         if type != 'list':
             newRequest['mbean'] = kwargs.get('mbean')


### PR DESCRIPTION
add support for remote targets.
useful, when multiple tomcat instances are behind a single jolokia service 