### PR TITLE
remove use_2to3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ class PyTest(Command):
         raise SystemExit(errno)
 
 setup(name='pyjolokia',
-      version='0.3.1',
+      version='0.3.2',
       description='Pure Python based Jolokia client',
       author='Colin Wood',
       license="Apache License Version 2.0",

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,4 @@
 from setuptools import setup, Command
-import sys
-
-kw = {}
-if sys.version_info >= (3,):
-        kw['use_2to3'] = True
 
 
 class PyTest(Command):
@@ -44,5 +39,4 @@ setup(name='pyjolokia',
           'Programming Language :: Python :: 3.3',
           'Topic :: Software Development :: Libraries :: Java Libraries',
       ],
-      **kw
 )


### PR DESCRIPTION
This package already supports python3. Removing the use_2to3 reference will allow this package to be installed via pip after the use_2to3 feature was removed in setuptools 58

https://setuptools.readthedocs.io/en/latest/history.html#v58-0-0